### PR TITLE
Добавлен BinaryThriftMetaInterceptor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,15 @@
 
     <groupId>livetex</groupId>
     <artifactId>flume-http-payload-handler</artifactId>
-    <version>1.0.11-SNAPSHOT</version>
+    <version>1.0.12-SNAPSHOT</version>
+
+    <repositories>
+        <repository>
+            <id>livetex_mvn_repo</id>
+            <name>Sonatype Livetex</name>
+            <url>http://sonatype-nexus.livetex.ru/nexus/content/groups/public</url>
+        </repository>
+    </repositories>
 
     <dependencies>
         <dependency>
@@ -19,8 +27,25 @@
             <groupId>org.apache.thrift</groupId>
             <artifactId>libthrift</artifactId>
             <version>0.8.0</version>
-            <scope>compile</scope>
+            <scope>provided</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <version>2.11.7</version>
+        </dependency>
+        <dependency>
+            <groupId>com.twitter</groupId>
+            <artifactId>scrooge-core_2.11</artifactId>
+            <version>4.5.0</version>
+        </dependency>
+        <dependency>
+            <groupId>ru.livetex</groupId>
+            <artifactId>scala-utils-kafka_2.11</artifactId>
+            <version>0.0.7-SNAPSHOT</version>
+        </dependency>
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/src/main/java/ru/livetex/flume/BinaryThriftMetaInterceptor.java
+++ b/src/main/java/ru/livetex/flume/BinaryThriftMetaInterceptor.java
@@ -1,0 +1,61 @@
+package ru.livetex.flume;
+
+import org.apache.flume.Context;
+import org.apache.flume.Event;
+import org.apache.flume.interceptor.Interceptor;
+import org.apache.thrift.protocol.TBinaryProtocol;
+import org.apache.thrift.protocol.TProtocol;
+import org.apache.thrift.protocol.TProtocolFactory;
+import org.apache.thrift.transport.TMemoryInputTransport;
+import org.apache.thrift.transport.TTransport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ru.livetex.kafka.gen.meta.MetaHolder;
+import ru.livetex.kafka.gen.meta.MetaHolder$;
+
+import java.util.List;
+
+
+public class BinaryThriftMetaInterceptor implements Interceptor {
+    private static final Logger logger = LoggerFactory.getLogger(BinaryThriftMetaInterceptor.class);
+    private static final String MESSAGE_TYPE_KEY = "message_type";
+    private static final String UNKNOWN_NAME = "unknown";
+    private static final TProtocolFactory protocolFactory = new TBinaryProtocol.Factory(true, true);
+
+    public void initialize() { }
+
+    public Event intercept(Event event) {
+        String messageType = extractMessageType(event.getBody());
+        event.getHeaders().put(MESSAGE_TYPE_KEY, messageType);
+        return event;
+    }
+
+    public List<Event> intercept(List<Event> events) {
+        for (Event event : events) {
+            intercept(event);
+        }
+        return events;
+    }
+
+    public void close() { }
+
+    private String extractMessageType(byte[] bytes) {
+        TTransport transport = new TMemoryInputTransport(bytes);
+        TProtocol protocol = protocolFactory.getProtocol(transport);
+        try {
+            MetaHolder holder = MetaHolder$.MODULE$.decode(protocol);
+            return Integer.toString(holder.meta().messageType());
+        } catch (Exception e) {
+            logger.warn("Can't extract livetex-meta from event");
+            return UNKNOWN_NAME;
+        }
+    }
+
+    public static class Builder implements Interceptor.Builder {
+        public Interceptor build() {
+            return new BinaryThriftMetaInterceptor();
+        }
+
+        public void configure(Context context) { }
+    }
+}

--- a/src/main/java/ru/livetex/flume/BinaryThriftMethodInterceptor.java
+++ b/src/main/java/ru/livetex/flume/BinaryThriftMethodInterceptor.java
@@ -7,12 +7,10 @@ import org.apache.thrift.protocol.TProtocolFactory;
 
 public class BinaryThriftMethodInterceptor extends ThriftMethodInterceptor {
     public static class Builder implements Interceptor.Builder {
-        @Override
         public Interceptor build() {
             return new BinaryThriftMethodInterceptor();
         }
 
-        @Override
         public void configure(Context context) {
         }
     }

--- a/src/main/java/ru/livetex/flume/HttpPayloadHandler.java
+++ b/src/main/java/ru/livetex/flume/HttpPayloadHandler.java
@@ -19,7 +19,6 @@ import javax.servlet.http.HttpServletRequest;
  */
 public class HttpPayloadHandler implements HTTPSourceHandler {
 
-    @Override
     public void configure(Context context) {
     }
 

--- a/src/main/java/ru/livetex/flume/JsonThriftMethodInterceptor.java
+++ b/src/main/java/ru/livetex/flume/JsonThriftMethodInterceptor.java
@@ -8,12 +8,10 @@ import org.apache.thrift.protocol.TProtocolFactory;
 
 public class JsonThriftMethodInterceptor extends ThriftMethodInterceptor {
     public static class Builder implements Interceptor.Builder {
-        @Override
         public Interceptor build() {
             return new JsonThriftMethodInterceptor();
         }
 
-        @Override
         public void configure(Context context) {
         }
     }


### PR DESCRIPTION
Он пытается распарсить тело события с помощью `MetaHolder` и добавляет в заголовки события поле `message_type` c типом сообщения котрое удалось распарсить или `unknown` иначе.
